### PR TITLE
Fix GitHub Pages 404 routing issue

### DIFF
--- a/.github/workflows/debug-pages.yml
+++ b/.github/workflows/debug-pages.yml
@@ -1,0 +1,263 @@
+name: Debug GitHub Pages
+
+on:
+  push:
+    branches: [main, 'claude/*']
+  workflow_dispatch:
+
+jobs:
+  debug-structure:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: "DEBUG: Repository structure"
+        run: |
+          echo "=========================================="
+          echo "REPOSITORY ROOT STRUCTURE"
+          echo "=========================================="
+          ls -la
+          echo ""
+
+          echo "=========================================="
+          echo "CNAME FILE CONTENTS"
+          echo "=========================================="
+          cat CNAME || echo "No CNAME file"
+          echo ""
+
+          echo "=========================================="
+          echo ".nojekyll FILES"
+          echo "=========================================="
+          find . -name ".nojekyll" -type f
+          echo ""
+
+      - name: "DEBUG: kaiserlift directory structure"
+        run: |
+          echo "=========================================="
+          echo "KAISERLIFT DIRECTORY TREE"
+          echo "=========================================="
+          find kaiserlift -type f | head -50
+          echo ""
+
+          echo "=========================================="
+          echo "KAISERLIFT DIRECTORY LISTING (detailed)"
+          echo "=========================================="
+          ls -laR kaiserlift/
+          echo ""
+
+      - name: "DEBUG: Compare lifting vs running"
+        run: |
+          echo "=========================================="
+          echo "FILE SIZE COMPARISON"
+          echo "=========================================="
+          wc -c kaiserlift/lifting/index.html kaiserlift/running/index.html
+          echo ""
+
+          echo "=========================================="
+          echo "LINE COUNT COMPARISON"
+          echo "=========================================="
+          wc -l kaiserlift/lifting/index.html kaiserlift/running/index.html
+          echo ""
+
+          echo "=========================================="
+          echo "FILE TYPE CHECK"
+          echo "=========================================="
+          file kaiserlift/lifting/index.html
+          file kaiserlift/running/index.html
+          echo ""
+
+          echo "=========================================="
+          echo "FILE PERMISSIONS"
+          echo "=========================================="
+          stat kaiserlift/lifting/index.html
+          stat kaiserlift/running/index.html
+          echo ""
+
+      - name: "DEBUG: Check for problematic content"
+        run: |
+          echo "=========================================="
+          echo "CHECK: Liquid template syntax ({{ or {%)"
+          echo "=========================================="
+          if grep -E '\{\{|\{%' kaiserlift/lifting/index.html; then
+            echo "WARNING: Found Liquid syntax!"
+          else
+            echo "OK: No Liquid syntax found"
+          fi
+          echo ""
+
+          echo "=========================================="
+          echo "CHECK: Null bytes"
+          echo "=========================================="
+          if grep -P '\x00' kaiserlift/lifting/index.html; then
+            echo "WARNING: Found null bytes!"
+          else
+            echo "OK: No null bytes found"
+          fi
+          echo ""
+
+          echo "=========================================="
+          echo "CHECK: Non-UTF8 characters"
+          echo "=========================================="
+          if ! iconv -f UTF-8 -t UTF-8 kaiserlift/lifting/index.html > /dev/null 2>&1; then
+            echo "WARNING: File contains invalid UTF-8!"
+          else
+            echo "OK: File is valid UTF-8"
+          fi
+          echo ""
+
+          echo "=========================================="
+          echo "CHECK: HTML structure (first/last lines)"
+          echo "=========================================="
+          echo "FIRST 5 LINES:"
+          head -5 kaiserlift/lifting/index.html
+          echo ""
+          echo "LAST 5 LINES:"
+          tail -5 kaiserlift/lifting/index.html
+          echo ""
+
+          echo "=========================================="
+          echo "CHECK: Embedded content counts"
+          echo "=========================================="
+          echo "Plotly charts: $(grep -c 'Plotly.newPlot' kaiserlift/lifting/index.html || echo 0)"
+          echo "Script tags: $(grep -c '<script' kaiserlift/lifting/index.html || echo 0)"
+          echo "Style tags: $(grep -c '<style' kaiserlift/lifting/index.html || echo 0)"
+          echo ""
+
+      - name: "DEBUG: Check for very long lines"
+        run: |
+          echo "=========================================="
+          echo "LONGEST LINE LENGTH"
+          echo "=========================================="
+          echo "lifting/index.html:"
+          awk '{ print length }' kaiserlift/lifting/index.html | sort -rn | head -3
+          echo ""
+          echo "running/index.html:"
+          awk '{ print length }' kaiserlift/running/index.html | sort -rn | head -3
+          echo ""
+
+      - name: "DEBUG: Git file status"
+        run: |
+          echo "=========================================="
+          echo "GIT LFS CHECK"
+          echo "=========================================="
+          git lfs ls-files 2>/dev/null || echo "Git LFS not configured"
+          echo ""
+
+          echo "=========================================="
+          echo "GIT FILE MODE"
+          echo "=========================================="
+          git ls-files -s kaiserlift/lifting/index.html kaiserlift/running/index.html
+          echo ""
+
+          echo "=========================================="
+          echo "GIT LOG FOR LIFTING"
+          echo "=========================================="
+          git log --oneline -5 -- kaiserlift/lifting/index.html
+          echo ""
+
+  validate-html:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install html5validator
+        run: pip install html5validator
+
+      - name: "DEBUG: Validate HTML (lifting)"
+        continue-on-error: true
+        run: |
+          echo "=========================================="
+          echo "HTML5 VALIDATION: lifting/index.html"
+          echo "=========================================="
+          html5validator --show-warnings kaiserlift/lifting/index.html || true
+          echo ""
+
+      - name: "DEBUG: Validate HTML (running)"
+        continue-on-error: true
+        run: |
+          echo "=========================================="
+          echo "HTML5 VALIDATION: running/index.html"
+          echo "=========================================="
+          html5validator --show-warnings kaiserlift/running/index.html || true
+          echo ""
+
+  test-serve:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: "DEBUG: Test local serve"
+        run: |
+          echo "=========================================="
+          echo "TESTING LOCAL HTTP SERVER"
+          echo "=========================================="
+          cd $GITHUB_WORKSPACE
+          python -m http.server 8000 &
+          SERVER_PID=$!
+          sleep 3
+
+          echo "Testing kaiserlift/index.html..."
+          curl -sI http://localhost:8000/kaiserlift/index.html | head -5
+
+          echo ""
+          echo "Testing kaiserlift/lifting/index.html..."
+          curl -sI http://localhost:8000/kaiserlift/lifting/index.html | head -5
+
+          echo ""
+          echo "Testing kaiserlift/running/index.html..."
+          curl -sI http://localhost:8000/kaiserlift/running/index.html | head -5
+
+          echo ""
+          echo "Testing kaiserlift/lifting/ (directory)..."
+          curl -sI http://localhost:8000/kaiserlift/lifting/ | head -5
+
+          kill $SERVER_PID || true
+          echo ""
+
+      - name: "DEBUG: Verify file content accessible"
+        run: |
+          echo "=========================================="
+          echo "FILE CONTENT CHECK (first 500 bytes)"
+          echo "=========================================="
+          echo "lifting/index.html:"
+          head -c 500 kaiserlift/lifting/index.html
+          echo ""
+          echo ""
+          echo "running/index.html:"
+          head -c 500 kaiserlift/running/index.html
+          echo ""
+
+  check-deployment-artifact:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: "DEBUG: Create test artifact for pages"
+        run: |
+          echo "=========================================="
+          echo "SIMULATING PAGES ARTIFACT"
+          echo "=========================================="
+          mkdir -p _site
+          cp -r * _site/ 2>/dev/null || true
+          rm -rf _site/_site 2>/dev/null || true
+
+          echo "Files in simulated _site:"
+          find _site -type f | head -30
+          echo ""
+
+          echo "Size of _site:"
+          du -sh _site/
+          echo ""
+
+          echo "kaiserlift structure in _site:"
+          ls -la _site/kaiserlift/
+          echo ""
+
+          echo "lifting directory in _site:"
+          ls -la _site/kaiserlift/lifting/
+          echo ""

--- a/kaiserlift/lifting/test.html
+++ b/kaiserlift/lifting/test.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Test Page - Lifting Path Works</title>
+</head>
+<body>
+    <h1>If you can see this, the /kaiserlift/lifting/ path works!</h1>
+    <p>This is a minimal test page to verify the path is accessible.</p>
+    <p>Generated: 2025-12-05</p>
+</body>
+</html>


### PR DESCRIPTION
- Add comprehensive debug-pages.yml workflow to diagnose the 404 issue
- Add test.html to verify if /kaiserlift/lifting/ path is accessible
- Workflow checks: file structure, HTML validation, UTF-8, null bytes, Liquid syntax, line lengths, and local serve tests