### PR TITLE
Add version tracking footer to all pages

### DIFF
--- a/blog/chatgpt_advice/index.html
+++ b/blog/chatgpt_advice/index.html
@@ -253,9 +253,13 @@
             </section>
 
         </div>
+        <!-- Version Footer -->
+        <div id="version-footer"></div>
         <!-- Bootstrap core JS-->
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
         <!-- Core theme JS-->
         <script src="../../js/scripts.js"></script>
+        <!-- Version tracking JS-->
+        <script src="../../js/version.js"></script>
     </body>
 </html>

--- a/blog/index.html
+++ b/blog/index.html
@@ -354,9 +354,13 @@
             </section>
 
         </div>
+        <!-- Version Footer -->
+        <div id="version-footer"></div>
         <!-- Bootstrap core JS-->
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
         <!-- Core theme JS-->
         <script src="../js/scripts.js"></script>
+        <!-- Version tracking JS-->
+        <script src="../js/version.js"></script>
     </body>
 </html>

--- a/css/styles.css
+++ b/css/styles.css
@@ -11003,3 +11003,37 @@ section.resume-section .resume-section-content {
     padding-bottom: 5rem;
   }
 }
+
+/* Version Footer */
+#version-footer {
+  position: fixed;
+  bottom: 0;
+  right: 0;
+  padding: 0.25rem 0.75rem;
+  background-color: rgba(73, 80, 87, 0.9);
+  font-size: 0.75rem;
+  font-family: "Muli", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  z-index: 1000;
+  border-top-left-radius: 0.25rem;
+}
+
+#version-footer a {
+  color: rgba(255, 255, 255, 0.7);
+  text-decoration: none;
+}
+
+#version-footer a:hover {
+  color: #bd5d38;
+  text-decoration: underline;
+}
+
+#version-footer span {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+@media (min-width: 992px) {
+  #version-footer {
+    right: 0;
+    left: auto;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -268,9 +268,13 @@
                 </div>
             </section>
         </div>
+        <!-- Version Footer -->
+        <div id="version-footer"></div>
         <!-- Bootstrap core JS-->
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
         <!-- Core theme JS-->
-        <script src="../js/scripts.js"></script>
+        <script src="js/scripts.js"></script>
+        <!-- Version tracking JS-->
+        <script src="js/version.js"></script>
     </body>
 </html>

--- a/js/version.js
+++ b/js/version.js
@@ -1,0 +1,65 @@
+// Version footer script - fetches commit info from GitHub API
+(function() {
+    const REPO_OWNER = 'douglastkaiser';
+    const REPO_NAME = 'douglastkaiser.github.io';
+    const BASE_VERSION = '1.0';
+
+    async function fetchVersionInfo() {
+        const footer = document.getElementById('version-footer');
+        if (!footer) return;
+
+        try {
+            const response = await fetch(
+                `https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/commits?per_page=1`,
+                { headers: { 'Accept': 'application/vnd.github.v3+json' } }
+            );
+
+            if (!response.ok) {
+                throw new Error('Failed to fetch commit info');
+            }
+
+            const commits = await response.json();
+            if (commits.length === 0) {
+                throw new Error('No commits found');
+            }
+
+            const commit = commits[0];
+            const sha = commit.sha;
+            const shortSha = sha.substring(0, 7);
+            const commitDate = new Date(commit.commit.committer.date);
+            const dateStr = commitDate.toISOString().split('T')[0].replace(/-/g, '');
+
+            // Get commit count for build number
+            const countResponse = await fetch(
+                `https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/commits?per_page=1`,
+                { headers: { 'Accept': 'application/vnd.github.v3+json' } }
+            );
+
+            // Use link header to get total count (approximate)
+            const linkHeader = countResponse.headers.get('Link');
+            let buildNumber = 1;
+            if (linkHeader) {
+                const match = linkHeader.match(/page=(\d+)>; rel="last"/);
+                if (match) {
+                    buildNumber = parseInt(match[1], 10);
+                }
+            }
+
+            const versionString = `v${BASE_VERSION}.${buildNumber}+g${shortSha}.d${dateStr}`;
+            const commitUrl = `https://github.com/${REPO_OWNER}/${REPO_NAME}/commit/${sha}`;
+
+            footer.innerHTML = `<a href="${commitUrl}" target="_blank" rel="noopener noreferrer">${versionString} (${shortSha})</a>`;
+
+        } catch (error) {
+            console.warn('Version info unavailable:', error.message);
+            footer.innerHTML = '<span>Version info unavailable</span>';
+        }
+    }
+
+    // Run when DOM is ready
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', fetchVersionInfo);
+    } else {
+        fetchVersionInfo();
+    }
+})();

--- a/projects/index.html
+++ b/projects/index.html
@@ -140,9 +140,13 @@
                 </div>
             </section>
         </div>
+        <!-- Version Footer -->
+        <div id="version-footer"></div>
         <!-- Bootstrap core JS-->
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
         <!-- Core theme JS-->
         <script src="../js/scripts.js"></script>
+        <!-- Version tracking JS-->
+        <script src="../js/version.js"></script>
     </body>
 </html>


### PR DESCRIPTION
Display git commit info at bottom-right of each page, showing version string with short SHA that links to the GitHub commit. Fetches latest commit info from GitHub API on page load.