### PR TITLE
Add Bayesian calculator equations note

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -11037,3 +11037,43 @@ section.resume-section .resume-section-content {
     left: auto;
   }
 }
+
+/* Bayesian Calculator Note */
+.bayesian-note {
+  background: #f8f9fa;
+  border-left: 4px solid #bd5d38;
+  padding: 1rem 1.25rem;
+  margin-top: 1.5rem;
+  border-radius: 0.25rem;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+}
+
+.bayesian-note .math-display {
+  display: block;
+  font-family: "Cambria Math", "Times New Roman", serif;
+  font-size: 1.05rem;
+  margin-bottom: 0.25rem;
+  color: #212529;
+}
+
+.bayesian-note .fraction {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.15rem;
+}
+
+.bayesian-note .numerator {
+  border-bottom: 1px solid #212529;
+  padding: 0 0.35rem;
+}
+
+.bayesian-note .denominator {
+  padding: 0 0.35rem;
+}
+
+.bayesian-note .math-variables {
+  font-size: 0.95rem;
+  margin: 0;
+  color: #495057;
+}

--- a/projects/index.html
+++ b/projects/index.html
@@ -102,6 +102,14 @@
                     <h3 class="mb-0">Globals (optional)</h3>
                     <input type="number" id="globalaverageRating" placeholder="Average Rating (3.5)">
                     <input type="number" id="global_n_Votes" placeholder="Total Votes (50)">
+                    <div class="bayesian-note">
+                        <h4 class="mb-2">Bayesian Average Equations</h4>
+                        <div class="math-display">B = <span class="fraction"><span class="numerator">n r + m C</span><span class="denominator">n + m</span></span></div>
+                        <p class="math-variables">B: posterior Bayesian average for the item</p>
+                        <p class="math-variables">r: item&rsquo;s observed average rating &nbsp;&nbsp; n: number of item ratings</p>
+                        <p class="math-variables">C: global average rating &nbsp;&nbsp; m: global vote count (strength of prior)</p>
+                        <div class="math-display">Comparison uses each item&rsquo;s B value to decide which score is stronger.</div>
+                    </div>
                     <script src="../js/bayesian.js"></script>
                 </div>
             </section>


### PR DESCRIPTION
## Summary
- add an explanatory note with Bayesian average equations below the calculator inputs
- style the equation block to resemble LaTeX formatting with fraction layout

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f62fb4a3c8333993f3195d4994ef0)