### PR TITLE
Improve Bayesian equation formatting and layout

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -11048,11 +11048,30 @@ section.resume-section .resume-section-content {
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
 }
 
+.bayesian-note .math-intro {
+  margin-bottom: 0.75rem;
+  color: #495057;
+}
+
+.bayesian-note .math-equation {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  margin-bottom: 0.75rem;
+}
+
+.bayesian-note .math-label {
+  font-weight: 600;
+  color: #212529;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.7rem;
+}
+
 .bayesian-note .math-display {
   display: block;
   font-family: "Cambria Math", "Times New Roman", serif;
-  font-size: 1.05rem;
-  margin-bottom: 0.25rem;
+  font-size: 1.15rem;
   color: #212529;
 }
 
@@ -11072,8 +11091,32 @@ section.resume-section .resume-section-content {
   padding: 0 0.35rem;
 }
 
-.bayesian-note .math-variables {
-  font-size: 0.95rem;
+.bayesian-note .math-definitions {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.5rem 1.5rem;
+  margin: 0 0 0.75rem;
+}
+
+.bayesian-note .math-definition {
+  margin: 0;
+}
+
+.bayesian-note .math-definition dt {
+  font-weight: 600;
+  color: #212529;
+  margin-bottom: 0.15rem;
+}
+
+.bayesian-note .math-definition dd {
   margin: 0;
   color: #495057;
+}
+
+.bayesian-note .math-callout {
+  background: #fff;
+  border-radius: 0.25rem;
+  padding: 0.5rem 0.75rem;
+  color: #495057;
+  border: 1px solid rgba(189, 93, 56, 0.2);
 }

--- a/projects/index.html
+++ b/projects/index.html
@@ -104,11 +104,34 @@
                     <input type="number" id="global_n_Votes" placeholder="Total Votes (50)">
                     <div class="bayesian-note">
                         <h4 class="mb-2">Bayesian Average Equations</h4>
-                        <div class="math-display">B = <span class="fraction"><span class="numerator">n r + m C</span><span class="denominator">n + m</span></span></div>
-                        <p class="math-variables">B: posterior Bayesian average for the item</p>
-                        <p class="math-variables">r: item&rsquo;s observed average rating &nbsp;&nbsp; n: number of item ratings</p>
-                        <p class="math-variables">C: global average rating &nbsp;&nbsp; m: global vote count (strength of prior)</p>
-                        <div class="math-display">Comparison uses each item&rsquo;s B value to decide which score is stronger.</div>
+                        <p class="math-intro">We compute a Bayesian-adjusted rating that blends each item&rsquo;s score with a global prior.</p>
+                        <div class="math-equation">
+                            <span class="math-label">Bayesian average</span>
+                            <div class="math-display">B = <span class="fraction"><span class="numerator">n r + m C</span><span class="denominator">n + m</span></span></div>
+                        </div>
+                        <dl class="math-definitions">
+                            <div class="math-definition">
+                                <dt>B</dt>
+                                <dd>Posterior Bayesian average for the item.</dd>
+                            </div>
+                            <div class="math-definition">
+                                <dt>r</dt>
+                                <dd>Item&rsquo;s observed average rating.</dd>
+                            </div>
+                            <div class="math-definition">
+                                <dt>n</dt>
+                                <dd>Number of ratings for the item.</dd>
+                            </div>
+                            <div class="math-definition">
+                                <dt>C</dt>
+                                <dd>Global average rating.</dd>
+                            </div>
+                            <div class="math-definition">
+                                <dt>m</dt>
+                                <dd>Global vote count (strength of the prior).</dd>
+                            </div>
+                        </dl>
+                        <div class="math-callout">Comparison uses each item&rsquo;s B value to decide which rating is stronger.</div>
                     </div>
                     <script src="../js/bayesian.js"></script>
                 </div>


### PR DESCRIPTION
### Motivation

- Make the "Bayesian Average Equations" section easier to read and understand by improving layout, wording, and visual hierarchy.
- Present the formula with a clear label, short intro, and explicit definitions for each symbol so readers can quickly grasp the meaning.

### Description

- Reworked the equation block in `projects/index.html`: added a short intro (`.math-intro`), a labeled equation block (`.math-equation` / `.math-label`), a semantic definition list (`.math-definitions` / `dt`/`dd`) and a highlighted callout (`.math-callout`).
- Replaced the inline variable lines with a structured `dl` to improve readability on small and large screens.
- Updated `css/styles.css` to add styles for the new classes: `.math-intro`, `.math-equation`, `.math-label`, `.math-definitions`, `.math-definition`, and `.math-callout`; tweaked `.math-display` font sizing for clarity and kept existing fraction layout.

### Testing

- Started a local static server with `python -m http.server 8000` and attempted an automated visual check via Playwright; the screenshot attempt timed out in this environment.
- No unit tests were added/required (static content/CSS change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945d705c1a483338e4c374eec6b5383)