### PR TITLE
Update Stones project section to match repository and add GitHub link

### DIFF
--- a/projects/index.html
+++ b/projects/index.html
@@ -81,9 +81,10 @@
             <!-- Stones -->
             <section class="resume-section" id="stones">
                 <div class="resume-section-content">
-                    <h2 class="mb-5">Atlas <span class="text-primary">Stones</span></h2>
-                    <div class="subheading mb-3">Strongman training log and tools.</div>
-                    <p class="mb-4"><a href="../stones/">Open the Stones site</a></p>
+                    <h2 class="mb-5">Stones: An Okay <span class="text-primary">Game</span></h2>
+                    <p class="mb-4"><a href="https://github.com/douglastkaiser/stones">stones on GitHub</a></p>
+                    <div class="subheading mb-3">A Flutter game project built for web and Android.</div>
+                    <p>The Stones project is a lightweight game built with Flutter. The repository is organized as an app you can run locally with <code>flutter run</code>, and it includes build targets for both web and Android, making it easy to iterate on gameplay and ship across platforms.</p>
                 </div>
             </section>
             <hr class="m-0" />


### PR DESCRIPTION
### Motivation
- The existing Stones entry on the Projects page described a strongman training log which did not match the actual repository content or README. 
- The projects page should present Stones consistently with other projects (e.g., Kaiserlift) by linking to the canonical repository and giving an accurate, concise description.

### Description
- Updated `projects/index.html` to change the Stones heading to the repository tagline "Stones: An Okay Game" and replaced the local site link with a GitHub link. 
- Replaced the incorrect strongman-copy with a short subheading and a one-line descriptive paragraph that reflects the README and notes that the project is a Flutter app you can run with `flutter run` and build for web and Android. 
- The only modified file is `projects/index.html` where the title, link, subheading, and descriptive paragraph were adjusted for accuracy.

### Testing
- No automated tests were run for this static HTML content change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d676c77bc8833396f18d3b4ef9a79b)