### PR TITLE
Add stable LaTeX resume source under resume/

### DIFF
--- a/resume/resume.tex
+++ b/resume/resume.tex
@@ -1,0 +1,37 @@
+\documentclass[11pt]{article}
+
+\usepackage[margin=1in]{geometry}
+\usepackage[T1]{fontenc}
+\usepackage[utf8]{inputenc}
+\usepackage{lmodern}
+\usepackage[hidelinks]{hyperref}
+\usepackage{enumitem}
+\setlist[itemize]{leftmargin=*, topsep=2pt, itemsep=2pt}
+\pagestyle{empty}
+
+\begin{document}
+
+\begin{center}
+    {\LARGE Your Name}\\
+    City, State \textbar{} \href{mailto:you@example.com}{you@example.com} \textbar{} (555) 555-5555 \textbar{} \href{https://example.com}{example.com}
+\end{center}
+
+\section*{Summary}
+Brief professional summary highlighting your experience, strengths, and goals.
+
+\section*{Experience}
+\textbf{Job Title} \hfill Company Name \hfill Start -- End\\
+Location
+\begin{itemize}
+    \item Accomplishment or responsibility with measurable impact.
+    \item Another accomplishment demonstrating scope, ownership, or outcomes.
+\end{itemize}
+
+\section*{Education}
+\textbf{Degree}, Major \hfill School Name \hfill Graduation Date\\
+Location
+
+\section*{Skills}
+Skill category: skill 1, skill 2, skill 3
+
+\end{document}


### PR DESCRIPTION
### Motivation

- Add a stable, CI-friendly LaTeX resume source so companion files (custom `.sty`, bibliography, etc.) can live under `resume/`, and ensure the repo contains exactly one complete LaTeX document from `\documentclass` to `\end{document}`.

### Description

- Add `resume/resume.tex` with a minimal, single-file LaTeX document using common packages (`geometry`, `fontenc`, `inputenc`, `lmodern`, `hyperref`, `enumitem`), simple placeholder sections (Summary, Experience, Education, Skills), and a single `\end{document}`.

### Testing

- No automated tests were run for this content-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f560f013688333a5601a174837baa2)