### PR TITLE
Add GitHub Actions workflow to build and publish resume PDF

### DIFF
--- a/.github/workflows/build-resume.yml
+++ b/.github/workflows/build-resume.yml
@@ -1,0 +1,46 @@
+name: Build Resume PDF
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'resume/**'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build-resume:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Build resume PDF
+        uses: xu-cheng/latex-action@v3
+        with:
+          root_file: resume.tex
+          working_directory: resume
+
+      - name: Copy PDF to publish path
+        run: |
+          mkdir -p assets
+          cp resume/resume.pdf assets/resume.pdf
+
+      - name: Commit and push updated PDF
+        run: |
+          if git diff --quiet -- assets/resume.pdf; then
+            echo "No changes to assets/resume.pdf"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add assets/resume.pdf
+          git commit -m "chore: rebuild resume PDF"
+          git push origin HEAD:main


### PR DESCRIPTION
### Motivation
- Ensure `resume/resume.tex` is automatically built into a PDF and the generated artifact is kept in the published site path.
- Trigger rebuilds on source changes under `resume/**` and allow manual rebuilds via `workflow_dispatch`.

### Description
- Adds a new workflow file at `.github/workflows/build-resume.yml` that runs on `push` to `main` when `resume/**` changes and on `workflow_dispatch`.
- Uses `actions/checkout@v4` and `xu-cheng/latex-action@v3` with `working_directory: resume` and `root_file: resume.tex` to produce `resume/resume.pdf`.
- Copies the generated PDF to `assets/resume.pdf` and commits/pushes the updated file back to `main` only when it differs from the current version.
- Grants `contents: write` permission to allow the workflow to update the repository with the rebuilt artifact.

### Testing
- Local verification commands including `git status --short` and `nl -ba .github/workflows/build-resume.yml` completed successfully and showed the new workflow file.
- No CI run was executed as part of this change in the repository during the update process.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f56198f2508333b154470cb2106743)