### PR TITLE
Publish resume at stable /assets/resume.pdf URL and trigger workflow on workflow changes

### DIFF
--- a/.github/workflows/build-resume.yml
+++ b/.github/workflows/build-resume.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - 'resume/**'
+      - '.github/workflows/build-resume.yml'
   workflow_dispatch:
 
 permissions:

--- a/index.html
+++ b/index.html
@@ -55,6 +55,7 @@
                     <div class="social-icons">
                         <a class="social-icon" href="https://www.linkedin.com/in/douglas-kaiser/"><i class="fab fa-linkedin-in"></i></a>
                         <a class="social-icon" href="https://github.com/douglastkaiser/"><i class="fab fa-github"></i></a>
+                        <a class="social-icon" href="https://www.douglastkaiser.com/assets/resume.pdf" title="Resume PDF" target="_blank" rel="noopener noreferrer"><i class="fa fa-file-pdf"></i></a>
                         <!-- <a class="social-icon" href="https://www.instagram.com/dtkaiser/"><i class="fab fa-instagram"></i></a> -->
                     </div>
                 </div>


### PR DESCRIPTION
### Motivation
- Ensure the generated resume is always reachable at a stable, single filename (`/assets/resume.pdf`) so external links and recruiters never break.
- Make the build pipeline run when the workflow itself changes so resume-publishing behavior can be validated immediately after CI updates.

### Description
- Add a homepage social icon that links to `https://www.douglastkaiser.com/assets/resume.pdf` in `index.html` so visitors can always access the stable resume URL.
- Update `.github/workflows/build-resume.yml` so the workflow is also triggered when the workflow file changes by adding `- '.github/workflows/build-resume.yml'` to the `paths` filter.
- Update files in the repository so the site references the canonical published location and the CI will copy `resume/resume.pdf` to `assets/resume.pdf` as before.

### Testing
- Ran `cd resume && pdflatex -interaction=nonstopmode resume.tex`, which failed because `pdflatex` is not installed in the current environment. (failed)
- Checked for the new link with `rg -n "resume.pdf|social-icons" index.html`, which located the inserted `https://www.douglastkaiser.com/assets/resume.pdf` entry. (succeeded)
- Inspected the workflow file with `sed -n` / `nl -ba` to confirm the added `paths` entry for `.github/workflows/build-resume.yml`. (succeeded)
- Verified that `assets/resume.pdf` is not present locally with `test -f assets/resume.pdf; echo $?`, which returned non-zero, indicating no local copy exists in this environment. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f56203c59c8333aed79b0b3c32f0ad)