### PR TITLE
Add Resume link to primary navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,6 +31,7 @@
                     <li class="nav-item"><a class="nav-link js-scroll-trigger" href="#skills">Skills</a></li>
                     <li class="nav-item"><a class="nav-link" href="projects/">Projects Page <i class="fa fa-external-link"></i></a></li>
                     <li class="nav-item"><a class="nav-link" href="blog/">Blog <i class="fa fa-external-link"></i></a></li>
+                    <li class="nav-item"><a class="nav-link" href="/assets/resume.pdf" target="_blank" rel="noopener">Resume <i class="fa fa-external-link"></i></a></li>
                 </ul>
             </div>
         </nav>


### PR DESCRIPTION
### Motivation
- Add a top-level `Resume` anchor in `index.html` primary navigation so visitors can open the site resume (`/assets/resume.pdf`) directly and with the same styling as other external links.

### Description
- Inserted a new `<li class="nav-item">` containing `<a class="nav-link" href="/assets/resume.pdf" target="_blank" rel="noopener">Resume <i class="fa fa-external-link"></i></a>` into the primary navigation list in `index.html`.

### Testing
- No automated tests were required for this static HTML change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f562b4b6648333871d01dce10fdda7)