### PR TITLE
Add /resume/ redirect page to serve resume PDF

### DIFF
--- a/resume/index.html
+++ b/resume/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Resume Redirect</title>
+    <link rel="canonical" href="/assets/resume.pdf" />
+    <meta http-equiv="refresh" content="0; url=/assets/resume.pdf" />
+    <script>
+      window.location.replace('/assets/resume.pdf');
+    </script>
+  </head>
+  <body>
+    <p>
+      Redirecting to <a href="/assets/resume.pdf">/assets/resume.pdf</a>...
+    </p>
+  </body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a memorable `/resume/` URL while still serving the raw PDF at `/assets/resume.pdf` for direct GET/download usage.

### Description
- Add `resume/index.html` which includes a canonical link to `/assets/resume.pdf`, a `meta` refresh redirect, a JavaScript redirect, and a visible anchor fallback.

### Testing
- Inspected the generated file and confirmed the canonical link plus `meta` refresh and JS redirect with `nl -ba resume/index.html | sed -n '1,120p'`, and ran `rg --files -g 'AGENTS.md'` to check repo constraints; both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5631d46cc8333a7e1ce281dda88d7)