### PR TITLE
ci: build resume and publish it in Pages artifact

### DIFF
--- a/.github/workflows/build-resume.yml
+++ b/.github/workflows/build-resume.yml
@@ -1,4 +1,4 @@
-name: Build Resume PDF
+name: Build and Deploy Pages
 
 on:
   push:
@@ -6,21 +6,29 @@ on:
       - main
     paths:
       - 'resume/**'
+      - 'assets/**'
       - '.github/workflows/build-resume.yml'
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
 
 jobs:
-  build-resume:
+  build:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
 
       - name: Build resume PDF
         uses: xu-cheng/latex-action@v3
@@ -33,15 +41,22 @@ jobs:
           mkdir -p assets
           cp resume/resume.pdf assets/resume.pdf
 
-      - name: Commit and push updated PDF
-        run: |
-          if git diff --quiet -- assets/resume.pdf; then
-            echo "No changes to assets/resume.pdf"
-            exit 0
-          fi
+      - name: Assert resume artifact exists
+        run: test -f assets/resume.pdf
 
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add assets/resume.pdf
-          git commit -m "chore: rebuild resume PDF"
-          git push origin HEAD:main
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: .
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
### Motivation
- Ensure `resume/resume.tex` is compiled during CI and the resulting PDF is included in the same workspace that is uploaded for GitHub Pages.
- Fail CI early if the generated `assets/resume.pdf` is missing and publish via the Pages artifact/deploy flow instead of committing the binary back to the repository.

### Description
- Replace the previous single-purpose workflow with a build/deploy Pages pipeline and broaden triggers to include `assets/**` and `resume/**` paths, add `pages` and `id-token` permissions, and introduce a `concurrency` group.
- Add `actions/configure-pages@v5` and a `xu-cheng/latex-action@v3` step that compiles `resume/resume.tex` with `root_file: resume.tex` and `working_directory: resume`.
- Copy the compiled file to exactly `assets/resume.pdf` and add an assertion step `test -f assets/resume.pdf` so the job fails when the file is missing.
- Upload the workspace via `actions/upload-pages-artifact@v3` with `path: .` and add a `deploy` job that runs `actions/deploy-pages@v4`; remove the prior step that committed the generated PDF back to the repo.

### Testing
- Verified the updated workflow file content locally with `sed -n '1,220p' .github/workflows/build-resume.yml`, which showed the new LaTeX build, copy, assertion, and upload steps and succeeded.
- Printed the workflow via `nl -ba .github/workflows/build-resume.yml | sed -n '1,220p'` to confirm structure and job names, which succeeded.
- No GitHub Actions run was executed here; the workflow will execute on push or manual dispatch in GitHub Actions and will fail if `assets/resume.pdf` is not produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f567341d988333998a23359489cb53)