### PR TITLE
Fix Pages artifact staging so resume PDF is uploaded with site root

### DIFF
--- a/.github/workflows/build-resume.yml
+++ b/.github/workflows/build-resume.yml
@@ -36,18 +36,30 @@ jobs:
           root_file: resume.tex
           working_directory: resume
 
-      - name: Copy PDF to publish path
+      - name: Stage site for artifact upload
         run: |
-          mkdir -p assets
-          cp resume/resume.pdf assets/resume.pdf
+          mkdir -p dist
+          rsync -a --exclude '.git' --exclude 'dist' ./ dist/
+          mkdir -p dist/assets
+          cp resume/resume.pdf dist/assets/resume.pdf
 
-      - name: Assert resume artifact exists
-        run: test -f assets/resume.pdf
+      - name: Assert staged artifact contains site root and resume
+        run: |
+          test -f dist/index.html
+          test -f dist/assets/resume.pdf
+
+      - name: Show staged artifact contents
+        run: |
+          echo "Top-level artifact entries:"
+          ls -la dist | sed -n '1,40p'
+          echo
+          echo "Assets entries (truncated):"
+          ls -la dist/assets | sed -n '1,60p'
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: .
+          path: dist
 
   deploy:
     environment:


### PR DESCRIPTION
### Motivation
- Ensure the Pages artifact root contains both `index.html` and the generated `assets/resume.pdf` so the resume is served with the site.
- Avoid writing generated files back into the repository working tree by staging a separate publish directory.
- Provide a small pre-upload listing in CI logs to make presence of the PDF and site root easy to verify.

### Description
- Stage the full site into `dist/` using `rsync` and copy `resume/resume.pdf` into `dist/assets/resume.pdf` instead of `assets/` in the repo.
- Add assertions that `dist/index.html` and `dist/assets/resume.pdf` exist before uploading the Pages artifact.
- Print a brief listing of `dist/` and `dist/assets/` to CI logs for verification prior to upload.
- Update the `actions/upload-pages-artifact` `path` from `.` to `dist` so the staged payload is uploaded.

### Testing
- Verified the workflow diff with `git diff -- .github/workflows/build-resume.yml` and inspected the changed file with `nl -ba .github/workflows/build-resume.yml`, both succeeded.
- Committed the updated workflow with `git commit -m "Fix Pages artifact staging for resume PDF"`, which completed successfully.
- No CI run of the updated workflow has been executed in this change set yet.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f567ecca8c83339028b6f928c69740)