### PR TITLE
Add post-deploy smoke checks for resume PDF endpoint

### DIFF
--- a/.github/workflows/build-resume.yml
+++ b/.github/workflows/build-resume.yml
@@ -72,3 +72,40 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+
+  post_deploy_smoke_check:
+    name: Post-deploy smoke check
+    runs-on: ubuntu-latest
+    needs: deploy
+
+    steps:
+      - name: Verify resume PDF endpoint and headers
+        run: |
+          set -euo pipefail
+
+          URL="https://www.douglastkaiser.com/assets/resume.pdf"
+          HEADER_FILE="$(mktemp)"
+
+          echo "Checking: ${URL}"
+          STATUS_CODE="$(curl -sS -L -o /dev/null -D "$HEADER_FILE" -w "%{http_code}" "$URL")"
+          CONTENT_TYPE="$(awk 'BEGIN{IGNORECASE=1} /^content-type:/{sub(/\r$/, "", $0); sub(/^content-type:[[:space:]]*/, "", $0); print tolower($0); exit}' "$HEADER_FILE")"
+
+          echo "HTTP status: ${STATUS_CODE}"
+          echo "Content-Type: ${CONTENT_TYPE}"
+
+          test "${STATUS_CODE}" = "200"
+          test "${CONTENT_TYPE}" = "application/pdf"
+
+      - name: Confirm endpoint is not a 404 page
+        run: |
+          set -euo pipefail
+
+          URL="https://www.douglastkaiser.com/assets/resume.pdf"
+          BODY_FILE="$(mktemp)"
+
+          curl -sS -L "$URL" -o "$BODY_FILE"
+
+          FILE_TYPE="$(file -b --mime-type "$BODY_FILE")"
+          echo "Downloaded MIME type: ${FILE_TYPE}"
+
+          test "${FILE_TYPE}" = "application/pdf"


### PR DESCRIPTION
### Motivation

- Ensure the public resume asset at `/assets/resume.pdf` continues to be served correctly and opens inline in browsers after Pages deploys.
- Preserve existing behavior where homepage links and `resume/index.html` both target `/assets/resume.pdf` so both entry points remain consistent.
- Catch regressions where the Pages site could serve an HTML 404 or wrong MIME type instead of the actual PDF.

### Description

- Kept homepage links in `index.html` unchanged and still pointing to `/assets/resume.pdf` (navbar and social icon links remain as-is).
- Kept `resume/index.html` redirect and canonical tag unchanged and still targeting `/assets/resume.pdf`.
- Added a new `post_deploy_smoke_check` job to `.github/workflows/build-resume.yml` that runs after deploy and verifies the resume endpoint by performing an HTTP GET to `https://www.douglastkaiser.com/assets/resume.pdf`, asserting the status code is `200`, the `Content-Type` header equals `application/pdf`, and that the downloaded file's MIME type (via `file --mime-type`) is `application/pdf`.

### Testing

- No automated tests were executed as part of this change locally; the new CI job `post_deploy_smoke_check` will run in GitHub Actions after Pages deployment and will pass only if the endpoint returns HTTP `200` and the response is a true PDF (`Content-Type: application/pdf` and `file` MIME type `application/pdf`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5686fdc0c833384ba3651149d8c31)