### PR TITLE
Add automated homepage link checker for Pages deploy validation

### DIFF
--- a/scripts/check_pages_deploy.py
+++ b/scripts/check_pages_deploy.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+from html.parser import HTMLParser
+from urllib.parse import urljoin, urlparse, urldefrag
+from urllib.request import Request, urlopen
+from urllib.error import HTTPError, URLError
+import ssl
+import sys
+
+BASE = 'https://www.douglastkaiser.com/'
+EXPECTED_RESUME = '/assets/resume.pdf'
+UAS = {
+    'desktop': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/124.0.0.0 Safari/537.36',
+    'mobile': 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 Version/17.0 Mobile/15E148 Safari/604.1',
+}
+
+class AnchorParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.anchors = []
+
+    def handle_starttag(self, tag, attrs):
+        if tag.lower() == 'a':
+            attrs_dict = dict(attrs)
+            href = attrs_dict.get('href')
+            if href:
+                self.anchors.append(href)
+
+def fetch(url: str, ua: str):
+    req = Request(url, headers={'User-Agent': ua})
+    with urlopen(req, timeout=20, context=ssl.create_default_context()) as resp:
+        body = resp.read().decode('utf-8', errors='replace')
+        return resp.status, body
+
+def check_status(url: str, ua: str):
+    req = Request(url, headers={'User-Agent': ua}, method='HEAD')
+    try:
+        with urlopen(req, timeout=20, context=ssl.create_default_context()) as resp:
+            return resp.status, None
+    except HTTPError as e:
+        if e.code in (405, 501):
+            try:
+                req = Request(url, headers={'User-Agent': ua}, method='GET')
+                with urlopen(req, timeout=20, context=ssl.create_default_context()) as resp:
+                    return resp.status, None
+            except Exception as inner:
+                return None, str(inner)
+        return e.code, None
+    except URLError as e:
+        return None, str(e)
+    except Exception as e:
+        return None, str(e)
+
+def classify(href: str):
+    if href.startswith(('mailto:', 'tel:', 'javascript:')):
+        return 'skip'
+    abs_url = urldefrag(urljoin(BASE, href)).url
+    parsed = urlparse(abs_url)
+    if parsed.scheme not in ('http', 'https'):
+        return 'skip'
+    if parsed.netloc == urlparse(BASE).netloc:
+        return 'internal', abs_url
+    return 'external', abs_url
+
+def run():
+    failed_internal = []
+    failed_external = []
+    resume_assertions = []
+
+    for label, ua in UAS.items():
+        status, body = fetch(BASE, ua)
+        print(f'[{label}] homepage status: {status}')
+        parser = AnchorParser()
+        parser.feed(body)
+        hrefs = parser.anchors
+        print(f'[{label}] anchors found: {len(hrefs)}')
+
+        resume_links = [h for h in hrefs if urldefrag(h).url == EXPECTED_RESUME or urldefrag(urlparse(h).path).url == EXPECTED_RESUME]
+        resume_visible = len(resume_links) > 0
+        resume_assertions.append((label, resume_visible, resume_links))
+
+        internal_urls, external_urls = set(), set()
+        for href in hrefs:
+            result = classify(href)
+            if result == 'skip':
+                continue
+            kind, abs_url = result
+            if kind == 'internal':
+                internal_urls.add(abs_url)
+            else:
+                external_urls.add(abs_url)
+
+        for link in sorted(internal_urls):
+            code, err = check_status(link, ua)
+            if err or code is None or code >= 400:
+                failed_internal.append((label, link, code, err))
+
+        for link in sorted(external_urls):
+            code, err = check_status(link, ua)
+            if err or code is None or code >= 400:
+                failed_external.append((label, link, code, err))
+
+    print('\nResume assertions:')
+    resume_ok = True
+    for label, visible, links in resume_assertions:
+        ok = visible and any(urldefrag(urlparse(h).path).url == EXPECTED_RESUME or urldefrag(h).url == EXPECTED_RESUME for h in links)
+        resume_ok = resume_ok and ok
+        print(f'- [{label}] visible={visible}, matches_target={ok}, hrefs={links}')
+
+    print('\nExternal link failures (non-blocking):')
+    if failed_external:
+        for item in failed_external:
+            print(' -', item)
+    else:
+        print(' - none')
+
+    print('\nInternal link failures (blocking):')
+    if failed_internal:
+        for item in failed_internal:
+            print(' -', item)
+    else:
+        print(' - none')
+
+    if not resume_ok:
+        print('\nFAIL: Resume link assertion failed.')
+        return 2
+    if failed_internal:
+        print('\nFAIL: Internal broken links detected.')
+        return 1
+    print('\nPASS: No internal broken links detected and resume assertion passed.')
+    return 0
+
+if __name__ == '__main__':
+    sys.exit(run())


### PR DESCRIPTION
### Motivation
- Ensure the deployed Pages site at `https://www.douglastkaiser.com/` is reachable and its homepage links are healthy after each deploy.
- Detect and fail on broken internal links to prevent regressions (resume PDF in particular).
- Report external-link failures separately as non-blocking to avoid flakiness from third-party sites.

### Description
- Add `scripts/check_pages_deploy.py`, a standalone script that fetches the homepage using two user agents (`desktop` and `mobile`) and parses all anchor tags.
- Classify anchors as internal or external, normalize URLs, and perform `HEAD` checks with a `GET` fallback for servers that reject `HEAD`.
- Assert resume-link visibility and target equality against `'/assets/resume.pdf'` for each UA, treat external failures as non-blocking, and return a non-zero exit code when any internal link check fails.

### Testing
- Ran `python scripts/check_pages_deploy.py` against the live site for both desktop and mobile UAs, which executed end-to-end.
- The script observed the homepage returned `200` for both UAs and the resume assertions passed for both UAs.
- External failures were reported non-blocking (`https://archive.ph/...` returned `429`), and an internal blocking failure was detected because `https://www.douglastkaiser.com/assets/resume.pdf` returned `404`, causing the script to exit with a failure status.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f568f3e78083338d866785f41a7b37)