### PR TITLE
Trigger Pages workflow on all pushes and add resume target reachability check

### DIFF
--- a/.github/workflows/build-resume.yml
+++ b/.github/workflows/build-resume.yml
@@ -4,10 +4,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - 'resume/**'
-      - 'assets/**'
-      - '.github/workflows/build-resume.yml'
   workflow_dispatch:
 
 permissions:

--- a/scripts/check_pages_deploy.py
+++ b/scripts/check_pages_deploy.py
@@ -65,6 +65,7 @@ def run():
     failed_internal = []
     failed_external = []
     resume_assertions = []
+    resume_target_checks = []
 
     for label, ua in UAS.items():
         status, body = fetch(BASE, ua)
@@ -77,6 +78,10 @@ def run():
         resume_links = [h for h in hrefs if urldefrag(h).url == EXPECTED_RESUME or urldefrag(urlparse(h).path).url == EXPECTED_RESUME]
         resume_visible = len(resume_links) > 0
         resume_assertions.append((label, resume_visible, resume_links))
+
+        resume_url = urljoin(BASE, EXPECTED_RESUME.lstrip('/'))
+        resume_code, resume_err = check_status(resume_url, ua)
+        resume_target_checks.append((label, resume_url, resume_code, resume_err))
 
         internal_urls, external_urls = set(), set()
         for href in hrefs:
@@ -106,6 +111,13 @@ def run():
         resume_ok = resume_ok and ok
         print(f'- [{label}] visible={visible}, matches_target={ok}, hrefs={links}')
 
+    print('\nResume target status checks:')
+    resume_target_ok = True
+    for label, url, code, err in resume_target_checks:
+        ok = (err is None and code is not None and code < 400)
+        resume_target_ok = resume_target_ok and ok
+        print(f'- [{label}] url={url}, status={code}, err={err}, ok={ok}')
+
     print('\nExternal link failures (non-blocking):')
     if failed_external:
         for item in failed_external:
@@ -123,6 +135,9 @@ def run():
     if not resume_ok:
         print('\nFAIL: Resume link assertion failed.')
         return 2
+    if not resume_target_ok:
+        print('\nFAIL: Resume target URL is not reachable.')
+        return 3
     if failed_internal:
         print('\nFAIL: Internal broken links detected.')
         return 1


### PR DESCRIPTION
### Motivation
- Ensure the Pages build-and-deploy workflow runs for any push to `main` instead of only changes to specific paths.
- Strengthen link-checking by verifying the resume target URL is actually reachable in addition to checking for presence of a link.

### Description
- Removed the `paths:` filter from `.github/workflows/build-resume.yml` so the workflow triggers on all pushes to `main` rather than only when certain paths change.
- Enhanced `scripts/check_pages_deploy.py` by adding `resume_target_checks` and logic to perform a direct HTTP status check of the resume target URL for each user agent.
- Added output of per-user-agent resume target status and a new failure path that returns exit code `3` when the resume target URL is not reachable.
- Kept existing external/internal link checks and resume link visibility assertions intact while making the resume target availability an explicit, blocking validation.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f56bf1fd8c8333a135299a6f14cce0)