### PR TITLE
Fix LaTeX ampersand escaping in resume

### DIFF
--- a/resume/resume.tex
+++ b/resume/resume.tex
@@ -100,7 +100,7 @@ Senior real-time controls and GNC engineer with $\sim$10 years building determin
 
 \role{Cornell Violet Nanosat}{Ithaca, NY}{ACS Team Lead / I\&T Engineer}{Aug 2013 - May 2016}
 \begin{itemize}
-  \item Owned integration & test of the ACS hardware stack including Honeywell CMGs, Fiber Optic Gyro, and Star Tracker
+  \item Owned integration \& test of the ACS hardware stack including Honeywell CMGs, Fiber Optic Gyro, and Star Tracker
   \item Led Day-In-The-Life testing of CMG steering laws as ACS operator
 \end{itemize}
 


### PR DESCRIPTION
## Summary
Fixed LaTeX special character escaping in the resume document to ensure proper rendering of ampersands.

## Changes
- Changed unescaped ampersand (`&`) to properly escaped ampersand (`\&`) in the Cornell Violet Nanosat experience section
  - This ensures the ampersand in "integration & test" renders correctly in the compiled PDF instead of being interpreted as a LaTeX table column separator

## Details
In LaTeX, the ampersand character (`&`) is a special character used for table column alignment and must be escaped with a backslash (`\&`) when used in regular text. This change corrects the formatting to follow proper LaTeX syntax conventions.

https://claude.ai/code/session_01Ai1FES7wTFaQDDpdrGKjSt